### PR TITLE
Fixed memory leak in tvm_openfile

### DIFF
--- a/tvm_file.c
+++ b/tvm_file.c
@@ -13,12 +13,6 @@ FILE* tvm_openfile(const char* filename, const char* extension, const char* mode
 	{
 		strcat(fname, extension);
 		pFile = fopen(fname, mode);
-
-		if(!pFile)
-		{
-			free(fname);
-			return NULL;
-		}
 	}
 
 	free(fname);


### PR DESCRIPTION
tvm_openfile would leak fname when a file was not found. It would also buffer overflow if the extension specified was longer than four characters, although that didn't really matter given the usage.
