### PR TITLE
Undefined Behavior when using stack_push()

### DIFF
--- a/tvm_stack.c
+++ b/tvm_stack.c
@@ -39,6 +39,7 @@ stack* create_stack()
 
 	s->items = NULL;
 	s->num_items = 0;
+    s->num_slots = 0;
 
 	return s;
 }


### PR DESCRIPTION
Unitialized stack struct member num_slots can cause undefined behavior when calling stack_push() for the first time.
