### PR TITLE
Fix for file input segfaults

### DIFF
--- a/tvm.c
+++ b/tvm.c
@@ -16,7 +16,8 @@ tvm_t* create_vm(char* filename)
 	vm->pProgram = create_program();
 	if(!vm->pProgram) return NULL;
 
-	interpret_program(vm->pProgram, filename, vm->pMemory);
+	if(interpret_program(vm->pProgram, filename, vm->pMemory)==1)
+		return NULL;
 
 	return vm;
 }

--- a/tvm_program.c
+++ b/tvm_program.c
@@ -25,11 +25,19 @@ int interpret_program(tvm_program_t* p, char* filename, tvm_memory_t* pMemory)
 	FILE* pFile = NULL;
 	char** tokens = NULL;
 	char line[128];
-
-	/* Attempt to open the file. If the file cannot be opened, try once more. */
 	int i;
-	for(i = 0; i < 2; i++)
-		if(!pFile) pFile = tvm_fopen(filename, ".vm", "r");
+
+	/* If no file name was specified, accept standard input */
+	if(filename == NULL)
+	{
+		pFile = stdin;
+	}
+	else
+	{
+		/* Attempt to open the file. If the file cannot be opened, try once more. */
+		for(i = 0; i < 2; i++)
+			if(!pFile) pFile = tvm_fopen(filename, ".vm", "r");
+	}
 
 	if(!pFile)
 	{


### PR DESCRIPTION
Hi,

this small patch prevents tinvym from segfaulting
when it is run with no arguments (stdin is then chosen
as input file) or when an non-existant file name is given
to it.
