### PR TITLE
Tweak linker argument syntax

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ AS = as
 
 CFLAGS = -Wall -pipe -Iinclude/
 OFLAGS = 
-LFLAGS = $(CFLAGS) -L lib/
+LFLAGS = $(CFLAGS) -Llib/
 ASFLAGS =
 PEDANTIC_FLAGS = -ansi -pedantic -pedantic-errors
 


### PR DESCRIPTION
Hi,

this patch changes linker argument syntax 
from -L _dir_ to -L_dir_.

Building fails with older linkers
with the former syntax, while the latter
is favoured by the main Unices' manuals.
