### PR TITLE
Improve tdb, add tdb/README

### DIFF
--- a/tdb/README
+++ b/tdb/README
@@ -1,0 +1,39 @@
+tdb is a debugging shell for tinyvm programs. It is somewhat similar to gdb.
+
+//////////////////////////////////////////////////
+// Table of Contents /////////////////////////////
+//////////////////////////////////////////////////
+0. INVOCATION
+1. COMMANDS
+
+//////////////////////////////////////////////////
+// 0. INVOCATION /////////////////////////////////
+//////////////////////////////////////////////////
+
+tdb expects a program name as its first argument:
+
+tdb program.vm
+
+//////////////////////////////////////////////////
+// 1. COMMANDS ///////////////////////////////////
+//////////////////////////////////////////////////
+
+Commands are shown in brackets here; the brackets
+must not be typed in.
+
+[break idx]
+Set a breakpoint at instruction index idx.
+
+[run]
+Run the program until a breakpoint is hit.
+(This command can only be issued once.)
+
+[continue]
+Resume execution after a breakpoint is hit.
+
+[step]
+Execute one instruction and pause. (Ignores breakpoints.)
+
+[q]
+Quit tdb.
+

--- a/tdb/main.c
+++ b/tdb/main.c
@@ -4,10 +4,15 @@
 
 int main(int argc, char** argv)
 {
-        tvm_t* vm = tvm_create(argv[1]);
+        tvm_t* vm = tvm_create();
+	
         if(vm)
         {
-                tdb_shell(vm);
+                if(argc < 2) return 0;
+
+                if(tvm_interpret(vm, argv[1]) == 0)
+                        tdb_shell(vm);
+
                 tvm_destroy(vm);
         }
 

--- a/tdb/tdb.c
+++ b/tdb/tdb.c
@@ -7,7 +7,7 @@
 #define MAX_TOKENS 3
 #define MAX_INPUT_LENGTH 256
 
-const char* commands[] = {"q", "run", "break", "step", 0};
+const char* commands[] = {"q", "run", "break", "step", "continue", 0};
 
 static void tokenize(char* str, char** tokens);
 static int cmd_to_idx(char* cmd);
@@ -15,6 +15,7 @@ static int cmd_to_idx(char* cmd);
 void tdb_shell(tvm_t* vm)
 {
 	int run = 1, i;
+	int running = 0;
 
 	char* tokens[MAX_TOKENS];
 	char str[MAX_INPUT_LENGTH];
@@ -26,7 +27,7 @@ void tdb_shell(tvm_t* vm)
 
         vm->pMemory->registers[0x8].i32 = vm->pProgram->start;
 
-	while(run)
+	while(run && !feof(stdin))
 	{
 		int retcode = 0;
 
@@ -39,19 +40,22 @@ void tdb_shell(tvm_t* vm)
 
 		switch(cmd_to_idx(tokens[0]))
 		{
-			case -0x1: printf("\nWARNING: \"%s\" is not a valid command.\n", tokens[0]); break;
+			case -0x1: printf("WARNING: \"%s\" is not a valid command.\n", tokens[0]); break;
 			case  0x0: run = 0; break;
-			case  0x1: retcode = tdb_run(vm, breakpoints, num_breakpoints); break;
+			case  0x1: if(running) printf("The program is already running.\n");
+				   else { retcode = tdb_run(vm, breakpoints, num_breakpoints); running = 1; } break;
 			case  0x2: breakpoints = realloc(breakpoints, sizeof(tdb_breakpoint_t) * ++num_breakpoints);
 				   breakpoints[num_breakpoints - 1].address = tvm_parse_value(tokens[1]); break;
 			case  0x3: tvm_step(vm, &vm->pMemory->registers[0x8].i32);
 				   vm->pMemory->registers[0x8].i32++;
 				   printf("Advancing instruction pointer to %i\n", vm->pMemory->registers[0x8].i32); break;
+			case  0x4: tvm_step(vm, &vm->pMemory->registers[0x8].i32);
+				   vm->pMemory->registers[0x8].i32++;
+				   retcode = tdb_run(vm, breakpoints, num_breakpoints); break;
 		};
 
+		if(vm->pProgram->instr[vm->pMemory->registers[0x8].i32] == -0x1) printf("End of program reached\n");
 		if(retcode == 1) printf("Breakpoint hit at address: %i\n", vm->pMemory->registers[0x8].i32);
-
-		printf("\n");
 	}
 
 	free(breakpoints);
@@ -70,7 +74,6 @@ int tdb_run(tvm_t* vm, tdb_breakpoint_t* breakpoints, int num_breakpoints)
 			if(breakpoints[i].address == *instr_idx) return 1; /* Breakpoint hit */
 
 		tvm_step(vm, instr_idx);
-
 	}
 
 	return 0;


### PR DESCRIPTION
The diff speaks for most of the changes; in the paragraph below I explain why I added a "continue" command.

Typing "run" after a breakpoint kept you stuck at the breakpoint and re-printed "hit breakpoint X". I changed this to emulate gdb: you can only type "run" once, and after a breakpoint is hit the "continue" command resumes execution until a breakpoint is hit again.
