### PR TITLE
Changing actual tab characters with escaped ones

### DIFF
--- a/libtvm/tvm_lexer.c
+++ b/libtvm/tvm_lexer.c
@@ -59,14 +59,14 @@ void lex(tvm_lexer_t* lexer, char* source)
 		lexer->tokens = (char***)realloc(lexer->tokens, sizeof(char**) * (i + 2));
 		lexer->tokens[i] = (char**)calloc(MAX_TOKENS, sizeof(char*));
 
-		pToken = strtok(lexer->source_lines[i], " 	,");
+		pToken = strtok(lexer->source_lines[i], " \t,");
 
 		for(j = 0; (pToken && j < MAX_TOKENS); j++)
 		{
 			lexer->tokens[i][j] = (char*)calloc(1, (strlen(pToken) + 1));
 			strcpy(lexer->tokens[i][j], pToken);
 
-			pToken = strtok(NULL, " 	,");
+			pToken = strtok(NULL, " \t,");
 		}
 	}
 


### PR DESCRIPTION
With some editors, these actual tab characters are implicitly replaced with spaces, causing the lexer to break on the next compilation. These changes may need to be applied to the other branches.
