### PR TITLE
Add hash-collision demo program

### DIFF
--- a/programs/hash-collision.vm
+++ b/programs/hash-collision.vm
@@ -1,0 +1,21 @@
+# On an x86/amd64 machine,
+# the labels "rose" and "verdict"
+# will hash to the same value;
+# tinyvm doesn't mind.
+
+rose:
+	mov eax, 456
+	prn eax
+	jmp end
+
+verdict:
+	mov eax, 123
+	prn eax
+	jmp rose
+
+start:
+	jmp verdict
+
+end:
+
+


### PR DESCRIPTION
The included program contains two labels that should hash to the same value on x86 or amd64 (i.e. 32-bit or 64-bit PC hardware).

Running it with the original hash table code prints out the error "Label 'verdict' defined twice".
