### PR TITLE
Patch tdb to compile with the new Makefile and gcc 4.6.3

### DIFF
--- a/tdb/tdb.c
+++ b/tdb/tdb.c
@@ -35,7 +35,8 @@ void tdb_shell(tvm_t *vm)
 
 		for(i = 0; i < MAX_TOKENS; i++) memset(tokens[i], 0, TOKEN_LENGTH);
 
-		fgets(str, MAX_INPUT_LENGTH, stdin);
+		if (!fgets(str, MAX_INPUT_LENGTH, stdin))
+			break;
 		tokenize(str, (char **)tokens);
 
 		switch(cmd_to_idx(tokens[0]))


### PR DESCRIPTION
Hello, I see that recently you updated the Makefile to abort when
warnings are encountered. As a result, the following happens when
I try to build tdb (my compiler is gcc 4.6.3):

tdb/tdb.c: In function ‘tdb_shell’:
tdb/tdb.c:38:8: error: ignoring return value of ‘fgets’, declared with attribute warn_unused_result [-Werror=unused-result]
cc1: all warnings being treated as errors
make: **\* [tdb/tdb.o] Error 1

The attached patch fixes the issue.

By the way, are you considering adding indexed/indirect addressing
to tinyvm ? It would allow local (stack) variables in routines and pointers,
which would make tinyvm really complete.
