### PR TITLE
Make program objects track defines.

### DIFF
--- a/include/tvm/tvm_preprocessor.h
+++ b/include/tvm/tvm_preprocessor.h
@@ -1,6 +1,8 @@
 #ifndef TVM_PREPROCESSOR_H_
 #define TVM_PREPROCESSOR_H_
 
-int tvm_preprocess(char *src, int *src_len);
+#include "tvm_htab.h"
+
+int tvm_preprocess(char *src, int *src_len, tvm_htab_t *htab);
 
 #endif

--- a/include/tvm/tvm_program.h
+++ b/include/tvm/tvm_program.h
@@ -20,6 +20,8 @@ typedef struct tvm_program_s
 	int **values;
 	int num_values;
 
+	tvm_htab_t *define_htab;
+
 	tvm_htab_t *label_htab;
 
 } tvm_program_t;

--- a/libtvm/tvm_preprocessor.c
+++ b/libtvm/tvm_preprocessor.c
@@ -3,7 +3,7 @@
 
 #include <string.h>
 
-int tvm_preprocess(char *src, int *src_len)
+int tvm_preprocess(char *src, int *src_len, tvm_htab_t *htab)
 {
 	char* pp_directive_delimiter = NULL;
 	if((pp_directive_delimiter = strstr(src, "%include")))
@@ -46,6 +46,45 @@ int tvm_preprocess(char *src, int *src_len)
 		for(int i = 0; i < new_src_len; i++) if(src[i] == 0) src[i] = ' ';
 
 		*src_len = strlen(src);
+		return 1;
+	}
+	else if ((pp_directive_delimiter = strstr(src, "%define")))
+	{
+		char *strbegin = pp_directive_delimiter, *strend = strchr(strbegin, '\n');
+
+		if (!strend || !strbegin) return 0;
+
+		char *define = (strchr(strbegin, ' ') + 1);
+		char *valstr = define ? (strchr(define, ' ') + 1) : NULL;
+
+		//Limit searching for value string to define's line
+		if (!define || !valstr || (valstr > strend)) {
+			*strend = 0;
+			printf("Define missing arguments: \"%s\"\n", strbegin);
+			*strend = '\n';
+			return 0;
+		}
+
+		*strend = '\n';
+
+		char *tmp = valstr - 1;
+		*tmp = 0;
+
+		int value = atoi(valstr);
+
+		htab_add(htab, define, value);
+
+		size_t first_block_len = (strbegin - src);
+		size_t second_block_len = ((src + *src_len) - strend);
+		size_t new_src_len = (first_block_len + second_block_len);
+
+		memcpy(&src[first_block_len], strend, second_block_len);
+
+		src = (char *)realloc((char *)src, sizeof(char) * new_src_len);
+		src[new_src_len] = 0;
+
+		*src_len = new_src_len;
+
 		return 1;
 	}
 

--- a/libtvm/tvm_program.c
+++ b/libtvm/tvm_program.c
@@ -8,6 +8,7 @@ tvm_program_t *program_create()
 {
 	tvm_program_t *p = (tvm_program_t *)calloc(1, sizeof(tvm_program_t));
 	p->label_htab = htab_create();
+	p->define_htab = htab_create();
 
 	return p;
 }
@@ -15,6 +16,7 @@ tvm_program_t *program_create()
 void program_destroy(tvm_program_t *p)
 {
 	htab_destroy(p->label_htab);
+	htab_destroy(p->define_htab);
 
 	if(p->values)
 	{
@@ -54,7 +56,7 @@ pi_interpret:
 	tvm_fcopy(source, source_length, pFile);
 	fclose(pFile);
 
-	while(tvm_preprocess(source, &source_length));
+	while(tvm_preprocess(source, &source_length, p->define_htab));
 
 	tvm_lexer_t *lexer_ctx = lexer_create();
 	lex(lexer_ctx, source);


### PR DESCRIPTION
Program objects will now track defines. The htab for defines will be passed
to the parser module in future committs, which will scan and replace any
instances of the defined string.

Possible modifications in future commits:
- Do not use an htab for defines; rather a list of structs with a key/val
- Use the integer value allocated for htab elements as a pointer to the
  value string instead of an integer.
