### PR TITLE
Scan build fixes

### DIFF
--- a/include/tvm/tvm_tokens.h
+++ b/include/tvm/tvm_tokens.h
@@ -4,21 +4,8 @@
 #define TOK_INCLUDE "%include"
 #define TOK_DEFINE "%define"
 
-static const char *tvm_opcode_map[] = {
-	"nop", "int", "mov",
-	"push", "pop", "pushf", "popf",
-	"inc", "dec", "add", "sub", "mul", "div", "mod", "rem",
-	"not", "xor", "or", "and", "shl", "shr",
-	"cmp", "jmp", "call", "ret",
-	"je", "jne", "jg", "jge", "jl", "jle",
-	"prn", 0
-};
+extern const char *tvm_opcode_map[];
 
-static const char *tvm_register_map[] = {
-	"eax", "ebx", "ecx", "edx",
-	"esi", "edi", "esp", "ebp",
-	"eip",
-	"r08", "r09", "r10", "r11",
-	"r12", "r13", "r14", "r15", 0};
+extern const char *tvm_register_map[];
 
 #endif

--- a/libtvm/tvm_htab.c
+++ b/libtvm/tvm_htab.c
@@ -110,7 +110,6 @@ static struct tvm_htab_node *htab_add_core(
 			node = node->next;
 
 		prev = node;
-		node = node->next;
 	}
 
 	/* Allocate space, and copy the key/value pair. */

--- a/libtvm/tvm_parser.c
+++ b/libtvm/tvm_parser.c
@@ -189,10 +189,13 @@ int tvm_parse_program(
 		int opcode = tvm_parse_instr(
 			vm, tokens[line_idx], &instr_place);
 
+		if (opcode == -1)
+			continue;
+
 		int **args = tvm_parse_args(
 			vm, tokens[line_idx], &instr_place);
 
-		if (opcode == -1 || !args)
+		if (!args)
 			continue;
 
 		void *newptr;

--- a/libtvm/tvm_parser.c
+++ b/libtvm/tvm_parser.c
@@ -3,6 +3,24 @@
 #include <tvm/tvm_lexer.h>
 #include <tvm/tvm_tokens.h>
 
+const char *tvm_opcode_map[] = {
+	"nop", "int", "mov",
+	"push", "pop", "pushf", "popf",
+	"inc", "dec", "add", "sub", "mul", "div", "mod", "rem",
+	"not", "xor", "or", "and", "shl", "shr",
+	"cmp", "jmp", "call", "ret",
+	"je", "jne", "jg", "jge", "jl", "jle",
+	"prn", 0
+};
+
+const char *tvm_register_map[] = {
+	"eax", "ebx", "ecx", "edx",
+	"esi", "edi", "esp", "ebp",
+	"eip",
+	"r08", "r09", "r10", "r11",
+	"r12", "r13", "r14", "r15", 0};
+
+
 static int *token_to_register(const char *token, struct tvm_mem *mem);
 static int instr_to_opcode(const char *instr);
 

--- a/libtvm/tvm_parser.c
+++ b/libtvm/tvm_parser.c
@@ -137,6 +137,19 @@ static int **tvm_parse_args(
 	return args;
 }
 
+/* This function frees the memory allocated by tvm_parse_args().
+ */
+static void tvm_free_args(int **args) {
+	if(args) {
+                for (int i = 0; args[i]; i++) {
+			free(args[i]);
+                }
+
+	}
+	free(args);
+}
+
+
 
 
 /* This is a helper function that converts one instruction,
@@ -190,8 +203,10 @@ int tvm_parse_program(
 		if (newptr != NULL) {
 			vm->prog->instr = newptr;
 			vm->prog->instr[vm->prog->num_instr - 1] = opcode;
-		} else
+		} else {
+			tvm_free_args(args);
 			return -1;
+                }
 
 		newptr = realloc(
 			vm->prog->args,
@@ -199,8 +214,10 @@ int tvm_parse_program(
 
 		if (newptr != NULL)
 			vm->prog->args = (int ***)newptr;
-		else
+		else {
+			tvm_free_args(args);
 			return -1;
+		}
 
 		vm->prog->args[vm->prog->num_instr - 1] = args;
 	}

--- a/libtvm/tvm_preprocessor.c
+++ b/libtvm/tvm_preprocessor.c
@@ -29,6 +29,7 @@ static int process_includes(
 
 	if (!filp) {
 		printf("Unable to open file \"%s\"\n", filename);
+		free(temp_str);
 		return -1;
 	}
 


### PR DESCRIPTION
This fixes a number of diagnostics which were shown with `scan-build make` on a Debian Stretch system (clang version 3.8.1-24).

Testing performed: at each ref, the software compiles, and `./bin/tvmi programs/tinyvm/euler/euler1.vm` produces the same output.