### PR TITLE
Add explicit void parameters

### DIFF
--- a/include/tvm/tvm.h
+++ b/include/tvm/tvm.h
@@ -16,7 +16,7 @@ struct tvm_ctx {
 	struct tvm_mem *mem;
 };
 
-struct tvm_ctx *tvm_vm_create();
+struct tvm_ctx *tvm_vm_create(void);
 void tvm_vm_destroy(struct tvm_ctx *vm);
 
 int tvm_vm_interpret(struct tvm_ctx *vm, char *filename);

--- a/include/tvm/tvm_htab.h
+++ b/include/tvm/tvm_htab.h
@@ -17,7 +17,7 @@ struct tvm_htab_ctx {
 	struct tvm_htab_node **nodes;
 };
 
-struct tvm_htab_ctx *tvm_htab_create();
+struct tvm_htab_ctx *tvm_htab_create(void);
 void tvm_htab_destroy(struct tvm_htab_ctx *htab);
 
 int tvm_htab_add(struct tvm_htab_ctx *htab, const char *key, int value);

--- a/include/tvm/tvm_lexer.h
+++ b/include/tvm/tvm_lexer.h
@@ -11,7 +11,7 @@ struct tvm_lexer_ctx {
 	char ***tokens;
 };
 
-struct tvm_lexer_ctx *lexer_create();
+struct tvm_lexer_ctx *lexer_create(void);
 void tvm_lexer_destroy(struct tvm_lexer_ctx *l);
 
 /* Tokenize the character array "source" into lines and tokens */

--- a/include/tvm/tvm_program.h
+++ b/include/tvm/tvm_program.h
@@ -23,7 +23,7 @@ struct tvm_prog {
 };
 
 /* Create and initialize an empty program object */
-struct tvm_prog *tvm_prog_create();
+struct tvm_prog *tvm_prog_create(void);
 
 void tvm_prog_destroy(struct tvm_prog *p);
 

--- a/libtvm/tvm.c
+++ b/libtvm/tvm.c
@@ -3,7 +3,7 @@
 #include <tvm/tvm_lexer.h>
 #include <tvm/tvm_parser.h>
 
-struct tvm_ctx *tvm_vm_create()
+struct tvm_ctx *tvm_vm_create(void)
 {
 	struct tvm_ctx *vm =
 		(struct tvm_ctx *)calloc(1, sizeof(struct tvm_ctx));

--- a/libtvm/tvm_htab.c
+++ b/libtvm/tvm_htab.c
@@ -5,7 +5,7 @@
 
 #define HTAB_LOAD_FACTOR 0.7
 
-struct tvm_htab_ctx  *tvm_htab_create()
+struct tvm_htab_ctx  *tvm_htab_create(void)
 {
 	struct tvm_htab_ctx *htab =
 		(struct tvm_htab_ctx *)calloc(1, sizeof(struct tvm_htab_ctx));

--- a/libtvm/tvm_lexer.c
+++ b/libtvm/tvm_lexer.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-struct tvm_lexer_ctx *lexer_create()
+struct tvm_lexer_ctx *lexer_create(void)
 {
 	return (struct tvm_lexer_ctx *)calloc(1, sizeof(struct tvm_lexer_ctx));
 }

--- a/libtvm/tvm_program.c
+++ b/libtvm/tvm_program.c
@@ -5,7 +5,7 @@
 #include <tvm/tvm_parser.h>
 #include <tvm/tvm.h>
 
-struct tvm_prog *tvm_prog_create()
+struct tvm_prog *tvm_prog_create(void)
 {
 	struct tvm_prog *p = calloc(1, sizeof(struct tvm_prog));
 


### PR DESCRIPTION
This should help accomodate some modern compilers and the aggressive errors parameters and -pedantic flags.